### PR TITLE
feat: accept i2c_addr config value

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ For example: the following configuration set up a servo on I2C bus 0, PCA9685 ch
 
 The name or number of the I2C bus to which the PCA9685 is connected.
 
+### i2c_addr
+
+*string (default: "0x40")*
+
+The number of the I2C address to which the PCA9685 is connected. This can be formatted as hex (prefixed by "0x") or base 10 (unprefixed) values.
+
+If you're not sure which address to use, see [this guide] for how to detect i2c devices. `i2cdetect` displays the hex formatted value.
+
 ### channel
 
 *int (default: 0)*

--- a/pca9685/pca9685.go
+++ b/pca9685/pca9685.go
@@ -5,6 +5,8 @@ package pca9685
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 	"sync"
 
 	"github.com/edaniels/golog"
@@ -42,6 +44,7 @@ type pca9685Servo struct {
 
 type Config struct {
 	I2cBus           string `json:"i2c_bus"`
+	I2cAddr          string `json:"i2c_addr"`
 	Channel          int    `json:"channel"`
 	Frequency        int    `json:"frequency_hz"`
 	MinAngle         int    `json:"min_angle_deg"`
@@ -125,7 +128,16 @@ func (servo *pca9685Servo) Reconfigure(
 		return err
 	}
 
-	pca, err := pca9685.NewI2C(bus, pca9685.I2CAddr)
+	i2cAddr := pca9685.I2CAddr
+	if newConf.I2cAddr != "" {
+		parsedAddr, err := strconv.ParseUint(newConf.I2cAddr, 0, 16)
+		if err != nil {
+			return err
+		}
+		i2cAddr = uint16(parsedAddr)
+	}
+
+	pca, err := pca9685.NewI2C(bus, i2cAddr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
A community member ran into an issue with this module when their servo board wasn't addressed to the default I2C address provided by periph.io (0x40). [Discord link](https://discord.com/channels/1083489952408539288/1323686172521791610/1323686172521791610)

This PR updates the configuration for the module to accept an `i2c_addr` field that defaults to "0x40". 